### PR TITLE
Oauth2 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.test
+*.idea

--- a/dcos-oauth/flags.go
+++ b/dcos-oauth/flags.go
@@ -30,4 +30,39 @@ var (
 		Usage: "Segment key",
 		Value: "39uhSEOoRHMw6cMR6st9tYXDbAL3JSaP",
 	}
+	flProtocol = cli.StringFlag{
+		Name:  "protocol",
+		Usage: "protocol",
+		Value: "oid",
+	}
+	flOauthAppKey = cli.StringFlag{
+		Name: "oauth-app-key",
+		Usage: "app key",
+		Value: "myApp key",
+	}
+	flOauthAppSecret = cli.StringFlag{
+		Name: "oauth-app-secret",
+		Usage: "app secret",
+		Value: "myApp secret",
+	}
+	flOauthTokenUrl = cli.StringFlag{
+		Name: "oauth-token-url",
+		Usage: "oauth-token-url",
+		Value: "https://oauth-token-url",
+	}
+	flOauthAuthUrl = cli.StringFlag{
+		Name: "oauth-auth-url",
+		Usage: "oauth-auth-url",
+		Value: "https://oauth-auth-url",
+	}
+	flOauthCallbackUrl = cli.StringFlag{
+		Name: "oauth-callback-url",
+		Usage: "oauth-callback-url",
+		Value: "https://oauth-callback-url",
+	}
+	flOauthProfileUrl = cli.StringFlag{
+		Name: "oauth-profile-url",
+		Usage: "profile url",
+		Value: "https://oauth/profile?access_token=",
+	}
 )

--- a/dcos-oauth/login.go
+++ b/dcos-oauth/login.go
@@ -18,145 +18,157 @@ import (
 )
 
 type loginRequest struct {
-	Uid string `json:"uid,omitempty"`
+	Uid      string `json:"uid,omitempty"`
 
 	Password string `json:"password,omitempty"`
 
-	Token string `json:"token,omitempty"`
+	Token    string `json:"token,omitempty"`
 }
 
 type loginResponse struct {
 	Token string `json:"token,omitempty"`
 }
 
+
 func handleLogin(ctx context.Context, w http.ResponseWriter, r *http.Request) *common.HttpError {
-	var lr loginRequest
-	err := json.NewDecoder(r.Body).Decode(&lr)
-	if err != nil {
-		log.Printf("Decode: %v", err)
-		return common.NewHttpError("JSON decode error", http.StatusBadRequest)
-	}
-
-	issuerURL, _ := ctx.Value("issuer-url").(string)
-	provCfg, err := oidc.FetchProviderConfig(httpClient, issuerURL)
-	if err != nil {
-		log.Printf("FetchProviderConfig: %v", err)
-		return common.NewHttpError("[OIDC] Fetch provider config error", http.StatusInternalServerError)
-	}
-
-	clientID, _ := ctx.Value("client-id").(string)
-
-	cliCfg := oidc.ClientConfig{
-		HTTPClient:     httpClient,
-		ProviderConfig: provCfg,
-		Credentials: oidc.ClientCredentials{
-			ID: clientID,
-		},
-	}
-	oidcCli, err := oidc.NewClient(cliCfg)
-	if err != nil {
-		log.Printf("oidc.NewClient: %v", err)
-		return common.NewHttpError("[OIDC] Client creation error", http.StatusInternalServerError)
-	}
-
-	token, err := jose.ParseJWT(lr.Token)
-	if err != nil {
-		log.Printf("ParseJWT: %v", err)
-		return common.NewHttpError("JWT parsing failed", http.StatusBadRequest)
-	}
-
-	err = oidcCli.VerifyJWT(token)
-	if err != nil {
-		log.Printf("VerifyJWT: %v", err)
-		return common.NewHttpError("JWT verification failed", http.StatusUnauthorized)
-	}
-
-	claims, err := token.Claims()
-	if err != nil {
-		log.Printf("Claims: %v", err)
-		return common.NewHttpError("invalid claims", http.StatusBadRequest)
-	}
-
-	// check for Auth0 email verification
-	if verified, ok := claims["email_verified"]; ok {
-		if b, ok := verified.(bool); ok && !b {
-			log.Printf("email not verified")
-			return common.NewHttpError("email not verified", http.StatusBadRequest)
-		}
-	}
-
-	uid, ok, err := claims.StringClaim("email")
-	if !ok || err != nil {
-		return common.NewHttpError("invalid email claim", http.StatusBadRequest)
-	}
-
-	c := ctx.Value("zk").(*zk.Conn)
-
-	users, _, err := c.Children("/dcos/users")
-	if err != nil && err != zk.ErrNoNode {
-		return common.NewHttpError("invalid email", http.StatusInternalServerError)
-	}
-
-	userPath := fmt.Sprintf("/dcos/users/%s", uid)
-	if len(users) == 0 {
-		// create first user
-		log.Printf("creating first user %v", uid)
-		err = common.CreateParents(c, userPath, []byte(uid))
+	protocol := ctx.Value("protocol")
+	if protocol == "oauth2" {
+		o2cli:=oauth2Client(ctx)
+		o2AuthUrl := o2cli.AuthCodeURL("d", "post", "")
+		log.Printf(o2AuthUrl)
+		http.Redirect(w,r,o2AuthUrl,302)
+	} else {
+		var lr loginRequest
+		err := json.NewDecoder(r.Body).Decode(&lr)
 		if err != nil {
-			return common.NewHttpError("Zookeeper error", http.StatusInternalServerError)
+			log.Printf("Decode: %v", err)
+			return common.NewHttpError("JSON decode error", http.StatusBadRequest)
 		}
+
+		issuerURL, _ := ctx.Value("issuer-url").(string)
+		log.Printf("issuerURL g: %v", issuerURL)
+
+		provCfg, err := oidc.FetchProviderConfig(httpClient, issuerURL)
+		if err != nil {
+			log.Printf("FetchProviderConfig: %v", err)
+			return common.NewHttpError("[OIDC] Fetch provider config error", http.StatusInternalServerError)
+		}
+
+		clientID, _ := ctx.Value("client-id").(string)
+
+		cliCfg := oidc.ClientConfig{
+			HTTPClient:     httpClient,
+			ProviderConfig: provCfg,
+			Credentials: oidc.ClientCredentials{
+				ID: clientID,
+			},
+		}
+		oidcCli, err := oidc.NewClient(cliCfg)
+		if err != nil {
+			log.Printf("oidc.NewClient: %v", err)
+			return common.NewHttpError("[OIDC] Client creation error", http.StatusInternalServerError)
+		}
+
+		token, err := jose.ParseJWT(lr.Token)
+		if err != nil {
+			log.Printf("ParseJWT: %v", err)
+			return common.NewHttpError("JWT parsing failed", http.StatusBadRequest)
+		}
+
+		err = oidcCli.VerifyJWT(token)
+		if err != nil {
+			log.Printf("VerifyJWT: %v", err)
+			return common.NewHttpError("JWT verification failed", http.StatusUnauthorized)
+		}
+
+		claims, err := token.Claims()
+		if err != nil {
+			log.Printf("Claims: %v", err)
+			return common.NewHttpError("invalid claims", http.StatusBadRequest)
+		}
+
+		// check for Auth0 email verification
+		if verified, ok := claims["email_verified"]; ok {
+			if b, ok := verified.(bool); ok && !b {
+				log.Printf("email not verified")
+				return common.NewHttpError("email not verified", http.StatusBadRequest)
+			}
+		}
+
+		uid, ok, err := claims.StringClaim("email")
+		if !ok || err != nil {
+			return common.NewHttpError("invalid email claim", http.StatusBadRequest)
+		}
+
+		c := ctx.Value("zk").(*zk.Conn)
+
+		users, _, err := c.Children("/dcos/users")
+		if err != nil && err != zk.ErrNoNode {
+			return common.NewHttpError("invalid email", http.StatusInternalServerError)
+		}
+
+		userPath := fmt.Sprintf("/dcos/users/%s", uid)
+		if len(users) == 0 {
+			// create first user
+			log.Printf("creating first user %v", uid)
+			err = common.CreateParents(c, userPath, []byte(uid))
+			if err != nil {
+				return common.NewHttpError("Zookeeper error", http.StatusInternalServerError)
+			}
+		}
+
+		exists, _, err := c.Exists(userPath)
+		if err != nil || !exists {
+			return common.NewHttpError("User unauthorized", http.StatusUnauthorized)
+		}
+
+		claims.Add("uid", uid)
+
+		secretKey, _ := ctx.Value("secret-key").([]byte)
+
+		clusterToken, err := jose.NewSignedJWT(claims, jose.NewSignerHMAC("secret", secretKey))
+		if err != nil {
+			return common.NewHttpError("JWT creation error", http.StatusInternalServerError)
+		}
+		encodedClusterToken := clusterToken.Encode()
+
+		const cookieMaxAge = 388800
+		// required for IE 6, 7 and 8
+		expiresTime := time.Now().Add(cookieMaxAge * time.Second)
+
+		authCookie := &http.Cookie{
+			Name:     "dcos-acs-auth-cookie",
+			Value:    encodedClusterToken,
+			Path:     "/",
+			HttpOnly: true,
+			Expires:  expiresTime,
+			MaxAge:   cookieMaxAge,
+		}
+		http.SetCookie(w, authCookie)
+
+		user := User{
+			Uid:         uid,
+			Description: uid,
+			IsRemote:    false,
+		}
+		userBytes, err := json.Marshal(user)
+		if err != nil {
+			log.Printf("Marshal: %v", err)
+			return common.NewHttpError("JSON marshalling failed", http.StatusInternalServerError)
+		}
+		infoCookie := &http.Cookie{
+			Name:    "dcos-acs-info-cookie",
+			Value:   base64.URLEncoding.EncodeToString(userBytes),
+			Path:    "/",
+			Expires: expiresTime,
+			MaxAge:  cookieMaxAge,
+		}
+		http.SetCookie(w, infoCookie)
+
+		json.NewEncoder(w).Encode(loginResponse{Token: encodedClusterToken})
+
+		return nil
 	}
-
-	exists, _, err := c.Exists(userPath)
-	if err != nil || !exists {
-		return common.NewHttpError("User unauthorized", http.StatusUnauthorized)
-	}
-
-	claims.Add("uid", uid)
-
-	secretKey, _ := ctx.Value("secret-key").([]byte)
-
-	clusterToken, err := jose.NewSignedJWT(claims, jose.NewSignerHMAC("secret", secretKey))
-	if err != nil {
-		return common.NewHttpError("JWT creation error", http.StatusInternalServerError)
-	}
-	encodedClusterToken := clusterToken.Encode()
-
-	const cookieMaxAge = 388800
-	// required for IE 6, 7 and 8
-	expiresTime := time.Now().Add(cookieMaxAge * time.Second)
-
-	authCookie := &http.Cookie{
-		Name:     "dcos-acs-auth-cookie",
-		Value:    encodedClusterToken,
-		Path:     "/",
-		HttpOnly: true,
-		Expires:  expiresTime,
-		MaxAge:   cookieMaxAge,
-	}
-	http.SetCookie(w, authCookie)
-
-	user := User{
-		Uid:         uid,
-		Description: uid,
-		IsRemote:    false,
-	}
-	userBytes, err := json.Marshal(user)
-	if err != nil {
-		log.Printf("Marshal: %v", err)
-		return common.NewHttpError("JSON marshalling failed", http.StatusInternalServerError)
-	}
-	infoCookie := &http.Cookie{
-		Name:    "dcos-acs-info-cookie",
-		Value:   base64.URLEncoding.EncodeToString(userBytes),
-		Path:    "/",
-		Expires: expiresTime,
-		MaxAge:  cookieMaxAge,
-	}
-	http.SetCookie(w, infoCookie)
-
-	json.NewEncoder(w).Encode(loginResponse{Token: encodedClusterToken})
-
 	return nil
 }
 

--- a/dcos-oauth/main.go
+++ b/dcos-oauth/main.go
@@ -14,7 +14,9 @@ func main() {
 		Name:      "serve",
 		ShortName: "s",
 		Usage:     "Serve the API",
-		Flags:     []cli.Flag{common.FlAddr, common.FlZkAddr, flIssuerURL, flClientID, flSecretKeyPath, flSegmentKey},
+		Flags:     []cli.Flag{common.FlAddr, common.FlZkAddr, flIssuerURL, flClientID, flSecretKeyPath,
+			flSegmentKey,flProtocol,flOauthAppKey,flOauthAppSecret,flOauthTokenUrl,flOauthAuthUrl,
+			flOauthProfileUrl,flOauthCallbackUrl},
 		Action:    action(serveAction),
 	}
 
@@ -27,7 +29,15 @@ func serveAction(c *cli.Context) error {
 	ctx = context.WithValue(ctx, "issuer-url", c.String("issuer-url"))
 	ctx = context.WithValue(ctx, "client-id", c.String("client-id"))
 	ctx = context.WithValue(ctx, "segment-key", c.String("segment-key"))
-
+	ctx = context.WithValue(ctx, "protocol", c.String("protocol"))
+	if(ctx.Value("protocol")=="oauth2") {
+		ctx = context.WithValue(ctx, "oauth-app-key", c.String("oauth-app-key"))
+		ctx = context.WithValue(ctx, "oauth-app-secret", c.String("oauth-app-secret"))
+		ctx = context.WithValue(ctx, "oauth-token-url", c.String("oauth-token-url"))
+		ctx = context.WithValue(ctx, "oauth-auth-url", c.String("oauth-auth-url"))
+		ctx = context.WithValue(ctx, "oauth-callback-url", c.String("oauth-callback-url"))
+		ctx = context.WithValue(ctx, "oauth-profile-url", c.String("oauth-profile-url"))
+	}
 	secretKey, err := common.ReadLine(c.String("secret-key-path"))
 	if err != nil {
 		return err

--- a/dcos-oauth/oauthCallback.go
+++ b/dcos-oauth/oauthCallback.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"github.com/dcos/dcos-oauth/common"
+	"net/http"
+	"golang.org/x/net/context"
+	"log"
+	"github.com/coreos/go-oidc/oauth2"
+	"time"
+	"encoding/json"
+	"io/ioutil"
+	"encoding/base64"
+)
+
+func oauth2Client(ctx context.Context) *oauth2.Client {
+	key := ctx.Value("oauth-app-key").(string)
+	secret := ctx.Value("oauth-app-secret").(string)
+	tokenUrl := ctx.Value("oauth-token-url").(string)
+	authUrl := ctx.Value("oauth-auth-url").(string)
+	callbackUrl := ctx.Value("oauth-callback-url").(string)
+
+	conf := oauth2.Config{
+		Credentials: oauth2.ClientCredentials{ID: key, Secret: secret},
+		Scope:       []string{"foo-scope", "bar-scope"},
+		TokenURL:    tokenUrl,
+		AuthMethod:  oauth2.AuthMethodClientSecretBasic,
+		RedirectURL: callbackUrl,
+		AuthURL:     authUrl,
+	}
+
+	o2cli, _ := oauth2.NewClient(httpClient, conf)
+	return o2cli
+}
+
+func handleCallback(ctx context.Context, w http.ResponseWriter, r *http.Request) *common.HttpError {
+	code := r.URL.Query()["code"]
+	o2cli := oauth2Client(ctx)
+	token, _ := o2cli.RequestToken(oauth2.GrantTypeAuthCode, code[0])
+	client := &http.Client{}
+
+	profileUrl := ctx.Value("oauth-profile-url").(string)+token.AccessToken
+	req, err := http.NewRequest("GET", profileUrl, nil)
+
+	resp, err := client.Do(req)
+	if err!=nil{
+		log.Print("error %w",err)
+	}
+	defer resp.Body.Close()
+	contents, err := ioutil.ReadAll(resp.Body)
+	userJson := string(contents)
+
+	const cookieMaxAge = 388800
+	// required for IE 6, 7 and 8
+	expiresTime := time.Now().Add(cookieMaxAge * time.Second)
+
+	authCookie := &http.Cookie{
+		Name:     "dcos-acs-auth-cookie",
+		Value:    token.AccessToken,
+		Path:     "/",
+		HttpOnly: true,
+		Expires:  expiresTime,
+		MaxAge:   cookieMaxAge,
+	}
+	http.SetCookie(w, authCookie)
+
+	user := User{
+		Uid:         userJson,
+		Description: userJson,
+		IsRemote:    false,
+	}
+	userBytes, err := json.Marshal(user)
+	if err != nil {
+		log.Printf("Marshal: %v", err)
+		return common.NewHttpError("JSON marshalling failed", http.StatusInternalServerError)
+	}
+	infoCookie := &http.Cookie{
+		Name:    "dcos-acs-info-cookie",
+		Value:   base64.URLEncoding.EncodeToString(userBytes),
+		Path:    "/",
+		Expires: expiresTime,
+		MaxAge:  cookieMaxAge,
+	}
+
+	http.SetCookie(w, infoCookie)
+	json.NewEncoder(w).Encode(loginResponse{Token: string(userJson)})
+	return nil
+}

--- a/dcos-oauth/routes.go
+++ b/dcos-oauth/routes.go
@@ -16,6 +16,8 @@ var routes = map[string]map[string]common.Handler{
 		"/acs/api/v1/auth/logout":       handleLogout,
 		"/acs/api/v1/users":             getUsers,
 		"/acs/api/v1/users/{uid:.*}":    getUser,
+		"/acs/api/v1/auth/login": 	 handleLogin,
+		"/oauth2/callback":     handleCallback,
 		"/acs/api/v1/groups":            getGroups,
 	},
 	"DELETE": {


### PR DESCRIPTION
Added endpoints 
   GET /acs/api/v1/auth/login
   GET /oauth2/callback
Added init params
--protocol "oauth2"
--oauth-auth-url "https://cas/oauth2.0/authorize"
--oauth-token-url "https://cas/oauth2.0/accessToken"
--oauth-profile-url "https://cas/oauth2.0/profile?access_token="
--oauth-callback-url "http://localhost:8081/oauth2/callback"
--oauth-app-key "app-example-client"
--oauth-app-secret "app-example-secret"

Usage:

I try to not change the app default behaviour, to enable this feature you should add before listed params to your init command

Disclaimer:

This is my first time with go-lang, so any comment will be welcome
