### PR TITLE
Normalize user email to be lower case

### DIFF
--- a/dcos-oauth/login.go
+++ b/dcos-oauth/login.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	"golang.org/x/net/context"
@@ -89,6 +90,7 @@ func handleLogin(ctx context.Context, w http.ResponseWriter, r *http.Request) *c
 	if !ok || err != nil {
 		return common.NewHttpError("invalid email claim", http.StatusBadRequest)
 	}
+	uid = strings.ToLower(uid)
 
 	c := ctx.Value("zk").(*zk.Conn)
 


### PR DESCRIPTION
Steps:
- User signed up for github with `First.Last@domain.tld`
- User added to dcos as `first.last@domain.tld` (validation won't allow anything else than lowercase)

Expected: User can login
Actual: User cannot login

This should fix it I think, but I'm unsure how to test it.
