### PR TITLE
dcos-oauth: fix tests

### DIFF
--- a/dcos-oauth/users_test.go
+++ b/dcos-oauth/users_test.go
@@ -49,7 +49,7 @@ func TestGetUsers(t *testing.T) {
 	assert.Nil(getUsers(ctx, w, r), "getUsers with valid parameters")
 
 	respBody, _ := ioutil.ReadAll(w.Body)
-	assert.Equal("{\"array\":[{\"uid\":\"\",\"description\":\"\",\"is_remote\":false}]}\n", string(respBody), "getUsers body")
+	assert.Equal("{\"array\":[{}]}\n", string(respBody), "getUsers body")
 }
 
 func TestValidateEmail(t *testing.T) {

--- a/test/integration/api_test.go
+++ b/test/integration/api_test.go
@@ -16,15 +16,17 @@ func TestUsers(t *testing.T) {
 
 	exampleEmail := "test@domain.com"
 	encoded := url.QueryEscape(exampleEmail)
-	// encoded := base64.StdEncoding.EncodeToString([]byte(exampleEmail))
 
-	getResponse := "{\"array\":[{\"uid\":\"" + exampleEmail + "\",\"description\":\"" + exampleEmail + "\",\"is_remote\":false}]}"
+	getResponse := "{\"array\":[{\"uid\":\"" + exampleEmail + "\",\"description\":\"" + exampleEmail + "\"}]}"
 
 	bodyGetUsers, err := send("GET", "/acs/api/v1/users", 200, nil)
 	assert.NoError(err)
 	assert.Equal("{\"array\":null}", bodyGetUsers, "Users list should be empty")
 
-	_, err = send("PUT", "/acs/api/v1/users/"+encoded, 201, nil)
+	user := struct {
+		Uid string `json:"uid"`
+	}{exampleEmail}
+	_, err = send("PUT", "/acs/api/v1/users/"+encoded, 201, user)
 	assert.NoError(err)
 
 	bodyGetUsers, err = send("GET", "/acs/api/v1/users", 200, nil)
@@ -33,7 +35,7 @@ func TestUsers(t *testing.T) {
 
 	bodyGetUser, err := send("GET", "/acs/api/v1/users/"+encoded, 200, nil)
 	assert.NoError(err)
-	assert.Equal("{\"uid\":\""+exampleEmail+"\",\"description\":\""+exampleEmail+"\",\"is_remote\":false}", bodyGetUser, "User should return address: test@domain.com")
+	assert.Equal("{\"uid\":\""+exampleEmail+"\",\"description\":\""+exampleEmail+"\"}", bodyGetUser, "User should return address: test@domain.com")
 
 	_, err = send("DELETE", "/acs/api/v1/users/"+encoded, 204, nil)
 	assert.NoError(err)


### PR DESCRIPTION
The dcos-oauth cmd expects user detail to be sent as json.
This request body cannot be left empty. This commit modifies the TestUsers
integration test to send minimal json along in the PUT request.

The cmd also marshals users to json through the User struct of which the fields are tagged
with 'json:omitempty'. This means empty or default values aren't in the response
JSON. I suspect the test fixtures were recorded before the omitempty tag was added to
the User struct definition.

This commit updates the expected responses in the failing tests to match current behaviour.
