### PR TITLE
dcos-oauth: fix email verification check

### DIFF
--- a/dcos-oauth/login.go
+++ b/dcos-oauth/login.go
@@ -79,7 +79,7 @@ func handleLogin(ctx context.Context, w http.ResponseWriter, r *http.Request) *c
 
 	// check for Auth0 email verification
 	if verified, ok := claims["email_verified"]; ok {
-		if b, ok := verified.(bool); ok && !b {
+		if b, ok := verified.(bool); !ok || !b {
 			log.Printf("email not verified")
 			return common.NewHttpError("email not verified", http.StatusBadRequest)
 		}


### PR DESCRIPTION
The verified check used to fail only if the input was a bool and false.
This fixes the condition so the check also fails if the
response is not a bool at all.

The external component's API would have to change to make this check fail
but since it is there we might as well have it guard against that.
