### PR TITLE
common: Bump zk connection timeout to 60s

### DIFF
--- a/common/serve.go
+++ b/common/serve.go
@@ -39,7 +39,7 @@ func CreateParents(c IZk, path string, data []byte) error {
 }
 
 func initZk(address, path string) (*zk.Conn, error) {
-	czk, _, err := zk.Connect([]string{address}, time.Second)
+	czk, _, err := zk.Connect([]string{address}, 60*time.Second)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Currently the dcos-oauth ZooKeeper connection timeout is hard-coded to 1 second. This is likely causing spurious 500's in constrained environments. This PR bumps the timeout to 60s.

See https://jira.mesosphere.com/browse/DCOS_OSS-1788